### PR TITLE
Use server Puppet Version

### DIFF
--- a/manifests/csr.pp
+++ b/manifests/csr.pp
@@ -154,7 +154,7 @@ define letsencrypt::csr(
         require => X509_request[$csr],
     }
 
-    if versioncmp($::puppetversion, '6.0') > 0 {
+    if versioncmp($::serverversion, '6.0') > 0 {
         $csr_content = pick_default(getvar("facts.'letsencrypt_csr_${domain}'"), '')
     } else {
         $csr_content = pick_default(getvar("::letsencrypt_csr_${domain}"), '')


### PR DESCRIPTION
In my environment the server and most clients are using puppet 6 put there are some clients still using puppet 5. Therefore server and client versions differ. When the server is evaluating the manifest it will have version 6 therefore it needs to use the first getvar variant.